### PR TITLE
タスクカードのカウント数と表示横幅の修正完了

### DIFF
--- a/app/views/tasks/_task_card.html.erb
+++ b/app/views/tasks/_task_card.html.erb
@@ -1,6 +1,5 @@
-<div class="col-md-6 mb-3">
-  <div class="card">
-    <!-- カードヘッダー：タスク名と状態 -->
+<div class="task-card card mb-3">
+  <!-- カードヘッダー：タスク名と状態 -->
     <div class="card-header d-flex justify-content-between align-items-center">
       <h5 class="mb-0"><%= task.name %></h5>
       <span class="badge bg-secondary">
@@ -53,5 +52,4 @@
             class: "btn btn-danger btn-sm",
             form: { class: "d-inline-block m-0 p-0" } %>
     </div>
-  </div>
 </div>

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -42,7 +42,7 @@
       <div class="card bg-info text-white">
         <div class="card-body text-center">
           <h5 class="card-title">未着手</h5>
-          <h2 class="mb-0"><%= @tasks.where(status: 'todo').count %></h2>
+          <h2 class="mb-0"><%= @tasks.where(status: 'not_started').count %></h2>
         </div>
       </div>
     </div>
@@ -66,7 +66,7 @@
       <div class="card bg-success text-white">
         <div class="card-body text-center">
           <h5 class="card-title">完了</h5>
-          <h2 class="mb-0"><%= @tasks.where(status: 'done').count %></h2>
+          <h2 class="mb-0"><%= @tasks.where(status: 'completed').count %></h2>
         </div>
       </div>
     </div>
@@ -159,16 +159,16 @@
           <h5 class="mb-0">
             <i class="fas fa-check-circle me-2"></i>完了
             <span class="badge bg-light text-dark ms-2">
-              <%= @tasks.where(status: 'done').count %>
+              <%= @tasks.where(status: 'completed').count %>
             </span>
           </h5>
         </div>
         <div class="kanban-body" id="done-column">
-          <% @tasks.where(status: 'done').order(:completed_at).each do |task| %>
+          <% @tasks.where(status: 'completed').order(:completed_at).each do |task| %>
             <%= render 'task_card', task: task %>
           <% end %>
           
-          <% if @tasks.where(status: 'done').empty? %>
+          <% if @tasks.where(status: 'completed').empty? %>
             <div class="empty-state">
               <i class="fas fa-inbox text-muted mb-2"></i>
               <p class="text-muted mb-0">タスクがありません</p>


### PR DESCRIPTION
## 作業内容
```
タスク一覧画面でのタスクカードのカウントが正しくされていない部分を修正

タスク一覧画面でのタスクカードの表示が正しくされていない部分を修正

タスク一覧画面でのタスクカードの横幅が状態カラムの幅と不揃いな部分を修正
```