### PR TITLE
サインイン時の確認メールへの導線追加

### DIFF
--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -80,7 +80,7 @@
 
 <!-- パスワード表示切り替え（登録画面と同等の操作感） -->
 <script>
-document.addEventListener('DOMContentLoaded', function() {
+document.addEventListener('turbo:load', function() {
   const toggleBtn = document.getElementById('loginPasswordToggle');
   const pwdField = document.querySelector('input[name="<%= resource_name %>[password]"]');
   const icon = document.getElementById('loginPasswordIcon');

--- a/config/locales/devise.ja.yml
+++ b/config/locales/devise.ja.yml
@@ -1,5 +1,12 @@
 ja:
   devise:
+    registrations:
+      signed_up_but_unconfirmed: "確認メールを送信しました。メールのリンクから登録を完了してください。"
+    confirmations:
+      send_instructions: "確認メールを送信しました。メールのリンクから登録を完了してください。"
+      send_paranoid_instructions: "確認メールを送信しました。メールのリンクから登録を完了してください。"
+    failure:
+      unconfirmed: "アカウントの確認が必要です。確認メールのリンクから登録を完了してください。"
     mailer:
       reconfirmation_instructions:
         subject: "【確認】メールアドレス変更の確定"


### PR DESCRIPTION
## 概要
サインイン時にユーザー確認メールへの導線がないので導線を追加する。



## 修正内容
・サインイン時の確認メール送信時にメール確認を促すフラッシュ(i18n)を追加する
・ログインページのパスワードの表示非表示のスクリプトを機能するように修正
